### PR TITLE
Turn insertEpics into getEpics

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -15,6 +15,13 @@ struct Image {
     3: optional string credit;
 }
 
+struct Epic {
+	1: required string title;
+	2: required string body;
+	3: required string firstButton;
+	4: optional string secondButton;
+}
+
 service Native {
     void insertAdverts(1:list<AdSlot> adSlots),
     i32 nativeThriftPackageVersion(),
@@ -24,4 +31,5 @@ service Native {
     bool isFollowing(1:Topic topic),
     bool isPremiumUser(),
     void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex),
+    list<Epic> getEpics(),
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -16,10 +16,10 @@ struct Image {
 }
 
 struct Epic {
-	1: required string title;
-	2: required string body;
-	3: required string firstButton;
-	4: optional string secondButton;
+    1: required string title;
+    2: required string body;
+    3: required string firstButton;
+    4: optional string secondButton;
 }
 
 struct MaybeEpic {

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -32,6 +32,5 @@ service Native {
     void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex),
     bool isFollowing(1:Topic topic),
     bool isPremiumUser(),
-    void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex),
     list<Epic> getEpics(),
 }

--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -22,6 +22,10 @@ struct Epic {
 	4: optional string secondButton;
 }
 
+struct MaybeEpic {
+    1: optional Epic epic;
+}
+
 service Native {
     i32 nativeThriftPackageVersion(),
     void insertAdverts(1:list<AdSlot> adSlots),
@@ -32,5 +36,5 @@ service Native {
     void launchSlideshow(1:list<Image> images, 2:i32 selectedIndex),
     bool isFollowing(1:Topic topic),
     bool isPremiumUser(),
-    list<Epic> getEpics(),
+    MaybeEpic getEpics(),
 }

--- a/thrift/webview.thrift
+++ b/thrift/webview.thrift
@@ -1,7 +1,4 @@
 service Webview {
-  i32 webviewThriftPackage(),
-	void updateFontSize(1:i32 size),
-}
 	i32 webviewThriftPackage(),
-	void insertEpic(1:Epic epic),
+	void updateFontSize(1:i32 size),
 }

--- a/thrift/webview.thrift
+++ b/thrift/webview.thrift
@@ -1,12 +1,3 @@
-struct Epic {
-	1: required string title;
-	2: required string body;
-	3: required string firstButton;
-	4: optional string secondButton;
-}
-
 service Webview {
     i32 webviewThriftPackage(),
-    void insertEpics(1:list<Epic> epics),
-	void insertEpic(1:Epic epic),
 }


### PR DESCRIPTION
This PR turns the `insertEpics` function from the `Webview` service into a `getEpics` function in the 'Native' interface.

`getEpics` should return a non-empty list of epics to be displayed, or an empty list if no epics should be displayed.

This PR is to support issue #12 