### PR TITLE
Add a java namespace

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -1,3 +1,5 @@
+namespace java com.theguardian.webview.thrift
+
 struct AdSlot {
     1: required i32 x;
     2: required i32 y;


### PR DESCRIPTION
This means the generated Java classes go into a package `com.theguardian.webview.thrift`.