### PR TITLE
Revert "Add a java namespace"

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -1,5 +1,3 @@
-namespace java com.theguardian.webview.thrift
-
 struct AdSlot {
     1: required i32 x;
     2: required i32 y;


### PR DESCRIPTION
Reverts guardian/mobile-apps-thrift#15 because it seems to affect the Typescript generated code as well, unfortunately.

This might be a bug in the Typescript Thrift compiler we're using, the spec for `namespace` declarations is here: https://thrift.apache.org/docs/idl#namespace and it looks like this change should only have affected Java generated code.