### PR TITLE
register epic was scrolled into viewport and seen by user

### DIFF
--- a/thrift/native.thrift
+++ b/thrift/native.thrift
@@ -37,4 +37,5 @@ service Native {
     bool isFollowing(1:Topic topic),
     bool isPremiumUser(),
     MaybeEpic getEpics(),
+    void epicSeen(),
 }


### PR DESCRIPTION
Will be used here: https://github.com/guardian/apps-rendering/pull/195/files#diff-de307717ea9472420901e5153c47b1ddR90

We currently only register an epic has been seen when it's been scrolled into the webview viewport. We use something like `signal_device('creative-impression')` in the templates.